### PR TITLE
removing xdebug as it's unused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN printf "deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main\ndeb-s
 # Then install node with:
 RUN apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
-    apt-get install -y --force-yes \
+    apt-get install -y \
     nodejs \
     git \
     bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,17 +33,6 @@ RUN apt-get install -y curl && \
 
 RUN docker-php-ext-install mcrypt pdo_pgsql mbstring pdo_mysql sockets opcache soap
 
-ENV XDEBUG_VERSION xdebug-2.4.0rc3
-RUN cd /tmp && \
-    curl -sL -o xdebug.tgz http://xdebug.org/files/$XDEBUG_VERSION.tgz && \
-    tar -xvzf xdebug.tgz && \
-    cd xdebug* && \
-    phpize && \
-    ./configure && make && \
-    cp modules/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012 && \
-    echo 'zend_extension = /usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so' >> /usr/local/etc/php/php.ini && \
-    rm -rf /tmp/xdebug*
-
 RUN which npm
 
 # Install npm global dependencies
@@ -80,13 +69,7 @@ RUN curl -sS# https://getcomposer.org/installer | php -- --install-dir=/usr/bin 
 
 # Configure php
 ADD config/memory.ini /opt/etc/memory.ini
-ADD config/xdebug.ini /opt/etc/xdebug.ini
-
-RUN sed -i "s|%data-root%|${DATA_ROOT:-/data}|" /opt/etc/xdebug.ini
-
-RUN cat /opt/etc/memory.ini >> /usr/local/etc/php/conf.d/memory.ini && \
-    cat /opt/etc/xdebug.ini >> /usr/local/etc/php/conf.d/xdebug.ini
-
+RUN cat /opt/etc/memory.ini >> /usr/local/etc/php/conf.d/memory.ini
 
 # Clean everything
 RUN npm config set tmp /root/.tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,14 @@ VOLUME ["/data"]
 
 #add custom ppa for git so that we get the latest version
 RUN printf "deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main\ndeb-src http://ppa.launchpad.net/git-core/ppa/ubuntu precise main" >> /etc/apt/sources.list.d/git-core.list && \
-    apt-get update || true && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E1DF1F24  && \
+    apt-get update || true
+
 
 # Then install node with:
 RUN apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
-    apt-get install -y \
+    apt-get install -y --force-yes \
     nodejs \
     git \
     bzip2 \
@@ -41,7 +42,7 @@ RUN cd /tmp && \
     phpize && \
     ./configure && make && \
     cp modules/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012 && \
-    echo 'zend_extension = /usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so' >> /usr/local/etc/php/php.ini && \
+    echo 'zend_extension = /usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     rm -rf /tmp/xdebug*
 
 RUN which npm
@@ -95,6 +96,9 @@ RUN npm config set tmp /root/.tmp && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     npm cache clear
+
+RUN printf "#!/bin/bash\nmv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.disabled" >> /usr/local/bin/xdebug-off
+RUN chmod +x /usr/local/bin/xdebug-off
 
 # Verify all install locations
 RUN which npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,13 @@ RUN npm config set tmp /root/.tmp && \
     npm cache clear
 
 RUN printf "#!/bin/bash\nmv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.disabled" >> /usr/local/bin/xdebug-off
+RUN printf "#!/bin/bash\nmv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.disabled /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini" >> /usr/local/bin/xdebug-on
 RUN chmod +x /usr/local/bin/xdebug-off
+RUN chmod +x /usr/local/bin/xdebug-on
+
+RUN mv /usr/bin/composer /usr/bin/composer-actual
+RUN printf '#!/bin/bash\nxdebug-off;/usr/bin/composer-actual "$@";xdebug-on' >> /usr/bin/composer && chmod +x /usr/bin/composer
+
 
 # Verify all install locations
 RUN which npm


### PR DESCRIPTION
Should this be a seperate branch? Different repo? Is there a better way to make this optional?
